### PR TITLE
ApiProvider and home bloc improvements

### DIFF
--- a/features/dashboard/lib/src/home/bloc/home_bloc.dart
+++ b/features/dashboard/lib/src/home/bloc/home_bloc.dart
@@ -17,17 +17,19 @@ class HomeBloc extends Bloc<HomeEvent, HomeState> {
     Emitter<HomeState> emit,
   ) async {
     try {
-      final List<PublicReportDto> trashReports =
-          await ApiProvider().getAllVisibleTrashReports();
-      final List<DumpDto> dumpReports =
-          await ApiProvider().getAllVisibleDumpReports();
-      final ReportStatisticsDto reportStatistics =
-          await ApiProvider().getReportStatistics();
+      final responses = await Future.wait(
+        [
+          ApiProvider().getAllVisibleTrashReports(),
+          ApiProvider().getAllVisibleDumpReports(),
+          ApiProvider().getReportStatistics(),
+        ],
+        eagerError: true,
+      );
       emit(
         ContentState(
-          trashReports: trashReports,
-          dumpReports: dumpReports,
-          reportStatistics: reportStatistics,
+          trashReports: responses[0] as List<PublicReportDto>,
+          dumpReports: responses[1] as List<DumpDto>,
+          reportStatistics: responses[2] as ReportStatisticsDto,
         ),
       );
     } catch (e) {


### PR DESCRIPTION
Looks like ApiProvider was intended to be used like a Singleton. This PR implements this and avoids multiple ApiProvider and ApiClient rebuilds for every request.

Also, for HomeBloc there is no need to synchronously wait for the responses, this PR addresses this by calling them asynchronously.