### PR TITLE
Dart 3.2 minimum constraint

### DIFF
--- a/core/pubspec.yaml
+++ b/core/pubspec.yaml
@@ -4,7 +4,8 @@ version: 1.0.0+1
 publish_to: none
 
 environment:
-  sdk: '>=3.0.0 <3.13.0'
+  sdk: ">=3.2.0 <3.13.0"
+  flutter: ">=3.16.0"
 
 dependencies:
   flutter:

--- a/core_ui/pubspec.yaml
+++ b/core_ui/pubspec.yaml
@@ -4,7 +4,8 @@ version: 1.0.0+1
 publish_to: none
 
 environment:
-  sdk: '>=3.0.0 <3.13.0'
+  sdk: ">=3.2.0 <3.13.0"
+  flutter: ">=3.16.0"
 
 dependencies:
   flutter:

--- a/features/admin/pubspec.yaml
+++ b/features/admin/pubspec.yaml
@@ -4,8 +4,8 @@ version: 0.0.1
 publish_to: "none"
 
 environment:
-  sdk: ">=3.0.0 <3.13.0"
-  flutter: ">=1.17.0"
+  sdk: ">=3.2.0 <3.13.0"
+  flutter: ">=3.16.0"
 
 dependencies:
   flutter:

--- a/features/dashboard/pubspec.yaml
+++ b/features/dashboard/pubspec.yaml
@@ -4,8 +4,8 @@ version: 0.0.1
 publish_to: none
 
 environment:
-  sdk: '>=3.0.0 <3.13.0'
-  flutter: ">=1.17.0"
+  sdk: ">=3.2.0 <3.13.0"
+  flutter: ">=3.16.0"
 
 dependencies:
   flutter:


### PR DESCRIPTION
# Motyvation
Dart 3.2 supports Non-null promotion for private final fields. Private final field promotion is available starting with Dart 3.2, and is applied to projects that have a Dart SDK lower bound of 3.2 or higher. 